### PR TITLE
:recycle: [Refactor] : ModalContext 타입 구체화

### DIFF
--- a/src/Context/ModalContext/ModalContext.tsx
+++ b/src/Context/ModalContext/ModalContext.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext, useState } from 'react';
+import { ModalContextValue } from '../../types/context';
 
 // 우선 임시로 any
-export const ModalContext = createContext<any>(null);
+export const ModalContext = createContext<ModalContextValue | null>(null);
 
 export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,0 +1,10 @@
+export interface LoginContextValue {
+  isLoggedIn: boolean;
+  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+interface ModalContextValue {
+  isModalOpen: boolean;
+  openModal: (children: React.ReactNode) => void;
+  closeModal: () => void;
+}

--- a/src/types/loginContext.ts
+++ b/src/types/loginContext.ts
@@ -1,4 +1,0 @@
-export interface LoginContextValue {
-  isLoggedIn: boolean;
-  setIsLoggedIn: React.Dispatch<React.SetStateAction<boolean>>;
-}


### PR DESCRIPTION
기존에 ModalContext 를 구현하던 도중 임시로 any로 지정했었던 ModalContext의 타입을 실제 사용하는 value값들의 타입으로 지정합니다