### PR TITLE
:recycle: [#25][Feat] : DB에 저장되는 유저 정보 키 값 일부 수정 및 안 쓰는 타입 제거

### DIFF
--- a/src/Pages/ChooseModeAndLogin/ChooseModeAndLogin.tsx
+++ b/src/Pages/ChooseModeAndLogin/ChooseModeAndLogin.tsx
@@ -51,13 +51,13 @@ const ChooseModeAndLogin = () => {
             const updateResult = doc(dbService, 'userInfo', `${documentIDForUpdate}`);
             await updateDoc(updateResult, {
               //googleUID와 nickname은 굳이 업데이트 x
-              accessId: result.accessId,
+              FIFAOnlineAccessId: result.accessId,
               level: result.level,
             });
 
             setUserObj({
               googleUID: user.uid,
-              accessId: result.accessId,
+              FIFAOnlineAccessId: result.accessId,
               level: result.level as unknown as number,
               nickname: result.nickname,
             });

--- a/src/components/AskNickNameModal/AskNickNameModal.tsx
+++ b/src/components/AskNickNameModal/AskNickNameModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useModalAPI } from '../../Context/Modal/ModalContext';
-import { NickNameInputProps } from '../../types/props';
 import { authService } from '../../../firebase';
 import { collection, addDoc, getDocs, updateDoc, doc } from 'firebase/firestore';
 import { dbService } from '../../../firebase';
@@ -9,7 +8,6 @@ import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
 
 const AskNickNameModal = () => {
   const [nickNameInput, setNickNameInput] = useState('');
-  const [data, setData] = useState({});
   const { closeModal } = useModalAPI()!;
   const { setUserObj } = useUserObjAPI()!;
 
@@ -28,7 +26,7 @@ const AskNickNameModal = () => {
         console.log(result);
         let obj = {
           googleUID: String(authService.currentUser?.uid),
-          accessId: result.accessId,
+          FIFAOnlineAccessId: result.accessId,
           level: result.level as unknown as number,
           nickname: result.nickname,
         };

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -11,7 +11,7 @@ export interface ModalContextValue {
 
 export interface userObjType {
   googleUID: string;
-  accessId: string;
+  FIFAOnlineAccessId: string;
   level: number;
   nickname: string;
 }

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,5 +1,0 @@
-export interface NickNameInputProps {
-  nickNameInput: string;
-  setNickNameInput: React.Dispatch<React.SetStateAction<string>>;
-  setIsNickNameExist: React.Dispatch<React.SetStateAction<boolean>>;
-}

--- a/src/types/test.ts
+++ b/src/types/test.ts
@@ -1,5 +1,0 @@
-export interface UserInfo {
-  accessId: string;
-  level: null;
-  nickname: string;
-}


### PR DESCRIPTION
구글uid와 넥슨피파온라인 계정api id를 서로 구분이 되는 값으로 수정하며 사용하지 않는 타입을 제거합니다