### PR TITLE
[#110][Feat] : 내 기록 페이지 레이아웃 전면 수정

### DIFF
--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
@@ -10,7 +10,10 @@ const paintTr = keyframes`
   }
 `;
 
-export const MatchResultsByMatchTypesContainer = styled.div``;
+export const MatchResultsByMatchTypesContainer = styled.div`
+  width: 50%;
+  margin-right: 2%;
+`;
 
 export const Table = styled.table`
   width: 100%;
@@ -24,8 +27,7 @@ export const Table = styled.table`
 
 export const TableHeaderDiv = styled.div`
   margin-top: 3%;
-  background-color: lightgray;
-  border-radius: 10px;
+  border-top: 5px solid black;
 `;
 
 export const TableContentDiv = styled.div`
@@ -51,12 +53,17 @@ export const TableContentDiv = styled.div`
 `;
 
 export const TableTh = styled.th`
-  padding: 20px 15px;
+  // padding: 20px 15px;
   text-align: center;
   font-weight: 500;
   font-size: 1.2rem;
-  color: black;
+  color: gray;
   text-transform: uppercase;
+`;
+export const TableThParagraph = styled.p`
+  margin: 0 20px;
+  padding: 15px 0;
+  border-bottom: 2px solid black;
 `;
 
 export const TableTr = styled.tr`

--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.tsx
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.tsx
@@ -11,6 +11,7 @@ import {
   TableHeaderDiv,
   TableTd,
   TableTh,
+  TableThParagraph,
   TableTr,
 } from './MatchResultsByMatchTypes.styled';
 import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
@@ -106,9 +107,15 @@ const MatchResultsByMatchTypes = () => {
         <Table cellPadding="0" cellSpacing="0">
           <thead>
             <tr>
-              <TableTh>상대</TableTh>
-              <TableTh>결과</TableTh>
-              <TableTh>매치 시간</TableTh>
+              <TableTh>
+                <TableThParagraph>상대</TableThParagraph>
+              </TableTh>
+              <TableTh>
+                <TableThParagraph>결과</TableThParagraph>
+              </TableTh>
+              <TableTh>
+                <TableThParagraph>매치 시간</TableThParagraph>
+              </TableTh>
             </tr>
           </thead>
         </Table>

--- a/src/Components/MatchStatistics/Player/Player.tsx
+++ b/src/Components/MatchStatistics/Player/Player.tsx
@@ -14,7 +14,6 @@ const Player = ({ shortCutPlayer }: PlayerProps) => {
           .filter((i) => {
             return i.spPosition !== 28;
           })
-
           .map((i, index) => {
             return (
               <li key={index}>

--- a/src/Components/MatchStatistics/Player/PlayerImg/PlayerImg.tsx
+++ b/src/Components/MatchStatistics/Player/PlayerImg/PlayerImg.tsx
@@ -25,11 +25,7 @@ const PlayerImg = ({ spId }: PlayerImgProps) => {
     getImage();
   }, [spId]);
 
-  return (
-    <div>
-      <img src={imgUrl!} alt="선수 이미지" />
-    </div>
-  );
+  return <img src={imgUrl!} alt="선수 이미지" />;
 };
 
 export default PlayerImg;

--- a/src/Components/TradeLog/TradeLog.styled.ts
+++ b/src/Components/TradeLog/TradeLog.styled.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const TradeLogContainerDiv = styled.div`
+  width: 50%;
+  margin-left: 2%;
+`;
+
+export const tmp = '';

--- a/src/Components/TradeLog/TradeLog.tsx
+++ b/src/Components/TradeLog/TradeLog.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
+import { TradeLogContainerDiv } from './TradeLog.styled';
 
 const TradeLog = () => {
-  return (
-    <div>
-      <h2>거래 목록</h2>
-    </div>
-  );
+  return <TradeLogContainerDiv>이적시장 목록</TradeLogContainerDiv>;
 };
 
 export default TradeLog;

--- a/src/Pages/MainSelect/MainSelect.styled.ts
+++ b/src/Pages/MainSelect/MainSelect.styled.ts
@@ -67,15 +67,6 @@ export const MyRecordDiv = styled.div<MyRecordSlideProps>`
   width: 80%; // 한 메뉴 전체의 폭을 80%해서 양 옆 여백을 줌
   padding: 3.5% 0% 3.5% 0%; // 나머지 메뉴들과 비율 통일
   margin: 0 auto;
-
-  // 1420px 이하 일 때는 메뉴의 너비가 전체 90% 차지
-  @media (max-width: 1420px) {
-    width: 90%;
-  }
-  // 1024px 이하 일 때는 메뉴의 너비가 전체를 차지
-  @media (max-width: 1024px) {
-    width: 100%;
-  }
 `;
 export const MyRecordLink = styled(Link)`
   display: flex;
@@ -85,7 +76,7 @@ export const MyRecordLink = styled(Link)`
   text-decoration: none;
 
   // 1024px 보다 커지면(전체 화면) 사진을 보여줌
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     width: 70%; // Link버튼 영역을 70%로 해서 옆에 RightDescriptionHeading의 구역을 확보
     // 투명도가 0일때는 rgb로 설정한 색상적용 안 되며
     // 투명도가 1일때는 rgb로 설정한 색상으로 되는 것이다
@@ -108,7 +99,10 @@ export const MyRecordLink = styled(Link)`
         rgba(233, 235, 238, 1) 100%
       ),
       url(${myRecord});
-    background-size: 60% 100%;
+
+    // background-size: 70% 100%; >> 원래는 높이값을 100%로 고정했는데
+    // 이렇게 되면 화면이 줄어들때 사진이 가로만 줄어들어서 이상함
+    background-size: 70%;
     background-repeat: no-repeat;
     background-position: left; // MyRecordLink 영역에서 살짝 왼쪽에 배치
     /* background-size: cover;
@@ -118,7 +112,10 @@ export const MyRecordLink = styled(Link)`
   // 1024px 보다 작아지면 사진을 가운데에 배치하며
   // 메뉴 옆 설명글(RightDescriptionHeading)을 제거
   @media (max-width: 1024px) {
-    width: 100%; // 어차피 옆에 RightDescriptionHeading 없으므로 사진이 전체 너비 차지
+    width: 100%;
+    // 화면이 1024px보다 작아지게 되면
+    // Link버튼 영역(사진부분)이 차지하는 부분이 늘어나게 되고
+    // 여기서 RightDescriptionHeading가 none이 되면 사진만이 메뉴 너비 전체를 차지
     background: linear-gradient(
         to right,
         rgba(233, 235, 238, 0) 10%,
@@ -167,24 +164,15 @@ export const UserRecordDiv = styled.div<UserRecordSlideProps>`
   width: 80%;
   padding: 3.5% 0% 3.5% 0%; // 윗 컴포넌트 3.5+ 현재컴포넌트 3.5해서 7%을 맞추기 3.5를 사용
   margin: 0 auto;
-
-  @media (max-width: 1420px) {
-    width: 90%;
-  }
-
-  @media (max-width: 1024px) {
-    width: 100%;
-  }
 `;
 export const UserRecordLink = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 70%;
   height: 100%;
   text-decoration: none;
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     width: 70%;
     background: linear-gradient(
         to right,
@@ -205,9 +193,9 @@ export const UserRecordLink = styled(Link)`
         rgba(233, 235, 238, 1) 100%
       ),
       url(${userRecord});
-    background-size: 60% 100%;
+    background-size: 70%;
     background-repeat: no-repeat;
-    background-position: left;
+    background-position: right;
   }
 
   @media (max-width: 1024px) {
@@ -257,24 +245,15 @@ export const PositionGuideDiv = styled.div<PositionGuideSlideProps>`
   width: 80%;
   margin: 0 auto;
   padding: 3.5% 0% 3.5% 0%;
-
-  @media (max-width: 1420px) {
-    width: 90%;
-  }
-
-  @media (max-width: 1024px) {
-    width: 100%;
-  }
 `;
 export const PositionGuideLink = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 70%;
   height: 100%;
   text-decoration: none;
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     width: 70%;
     background: linear-gradient(
         to right,
@@ -295,7 +274,7 @@ export const PositionGuideLink = styled(Link)`
         rgba(233, 235, 238, 1) 100%
       ),
       url(${positionGuide});
-    background-size: 60% 100%;
+    background-size: 70%;
     background-repeat: no-repeat;
     background-position: left;
   }
@@ -347,24 +326,15 @@ export const ChallengeDiv = styled.div<ChallengeSliceProps>`
   width: 80%;
   margin: 0 auto;
   padding: 3.5% 0% 3.5% 0%;
-
-  @media (max-width: 1420px) {
-    width: 90%;
-  }
-
-  @media (max-width: 1024px) {
-    width: 100%;
-  }
 `;
 export const ChallengeLink = styled(Link)`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 70%;
   height: 100%;
   text-decoration: none;
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     width: 70%;
     background: linear-gradient(
         to right,
@@ -385,9 +355,9 @@ export const ChallengeLink = styled(Link)`
         rgba(233, 235, 238, 1) 100%
       ),
       url(${challenge});
-    background-size: 60% 100%;
+    background-size: 70%;
     background-repeat: no-repeat;
-    background-position: left;
+    background-position: right;
   }
 
   @media (max-width: 1024px) {
@@ -440,7 +410,7 @@ export const RightDescriptionHeading = styled.h1`
   }
 
   // 1024px보다 커지면 보여줌
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     display: block;
     padding-top: 10%;
     padding-left: 5%;
@@ -454,7 +424,7 @@ export const LeftDescriptionHeading = styled.h1`
     display: none;
   }
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     display: block;
     padding-top: 10%;
     padding-right: 5%;

--- a/src/Pages/MainSelect/MainSelect.tsx
+++ b/src/Pages/MainSelect/MainSelect.tsx
@@ -113,7 +113,7 @@ const MainSelect = () => {
           </Fade>
         </MainMenuDescriptionDiv>
         <ScrollNoticeDiv scrollPoint={Number((window.pageYOffset / ELEMENT_HEIGHT).toFixed(2))}>
-          <ScrollNoticeParagraph>스크롤 해서 확인!</ScrollNoticeParagraph>
+          <ScrollNoticeParagraph>스크롤 해서 확인</ScrollNoticeParagraph>
         </ScrollNoticeDiv>
 
         <MyRecordDiv myRecord={slideInfo.myRecord}>

--- a/src/Pages/MyRecord/MyRecord.styled.ts
+++ b/src/Pages/MyRecord/MyRecord.styled.ts
@@ -1,13 +1,4 @@
-import styled, { keyframes } from 'styled-components';
-
-const paintButton = keyframes`
-  from {
-    width: 0;
-  }
-  to {
-    width: 100%;
-  }
-`;
+import styled from 'styled-components';
 
 export const MyRecordContainerDiv = styled.div`
   width: 70%;
@@ -17,7 +8,7 @@ export const MyRecordContainerDiv = styled.div`
 export const UserNameAndTopRankDiv = styled.div`
   padding: 8% 0 4% 0;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: flex-end;
   border-bottom: 2px solid black;
 `;
@@ -32,56 +23,18 @@ export const TopRankDiv = styled.div`
   color: gray;
 `;
 
-export const ChooseStatisticsUl = styled.ul`
-  list-style: none;
+export const DescriptionDiv = styled.div`
   display: flex;
-  // justify-content: space-around; // flex-grow때문에 사용할 필요가 없음
-  padding-left: 0;
-  margin: 7% 0;
+  justify-content: center;
+  align-items: center;
+  margin: 3.5% 0;
 `;
 
-export const MatchResultsByMatchTypesList = styled.li`
-  height: 50px;
-  flex-grow: 1; // 2개의 버튼이 나머지 너비를 전부 차지하게 함
-  width: 30%; // 지정을 해 줘야 각 li의 크기가 글자수(=버튼의 크기)만큼 차지하지 않고
-  // 서로 동일한 너비를 가짐
-
+export const DescriptionParagraph = styled.p`
   color: gray;
-  &:hover {
-    transform: translateY(-5px);
-    color: white;
-  }
-  transition: transform 0.3s ease;
-
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 0;
-    height: 100%;
-    background: #6ab04d;
-    transition: width 0.3s;
-    z-index: -1;
-  }
-
-  &:hover:after {
-    animation: ${paintButton} 0.3s forwards;
-  }
+  font-size: 1.5rem;
 `;
 
-export const StatisticsSelectionButton = styled.button`
-  // li의 너비와 높이를 전부 버튼의 영역으로 사용
-  width: 100%;
-  height: 100%;
-  border: none;
-  background-color: transparent;
-  font-size: 1.4rem;
-  font-weight: 900;
-  color: inherit;
-  cursor: pointer;
-`;
-
-export const Test = styled.div`
-  border-bottom: 1px solid black;
+export const ContentDiv = styled.div`
+  display: flex;
 `;

--- a/src/Pages/MyRecord/MyRecord.tsx
+++ b/src/Pages/MyRecord/MyRecord.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
-  ChooseStatisticsUl,
-  MatchResultsByMatchTypesList,
+  ContentDiv,
+  DescriptionDiv,
+  DescriptionParagraph,
   MyRecordContainerDiv,
-  StatisticsSelectionButton,
-  Test,
   TopRankDiv,
   UserNameAndTopRankDiv,
   UserNameParagraph,
@@ -26,7 +25,6 @@ const MyRecord = () => {
   const [matchId, setMatchId] = useState<string[]>([]);
   const [matchDetail, setMatchDetail] = useState<MatchDetail[]>([]);
   const [maxdivision, setMaxdivision] = useState<Maxdivision[] | null>(null);
-  const [mode, setMode] = useState(0);
 
   useEffect(() => {
     const updateMaxdivision = async () => {
@@ -65,12 +63,6 @@ const MyRecord = () => {
     getMatchDetail();
   }, [matchId]);
 
-  const onChooseStatisticsClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    const { name, value } = e.currentTarget;
-    if (name === 'MatchResultsByMatchTypes') setMode(0);
-    if (name === 'TradeLog') setMode(1);
-  };
-
   console.log(matchDetail);
 
   return (
@@ -93,23 +85,14 @@ const MyRecord = () => {
           </TopRankDiv>
         </UserNameAndTopRankDiv>
 
-        <ChooseStatisticsUl>
-          <MatchResultsByMatchTypesList>
-            <StatisticsSelectionButton type="button" name="MatchResultsByMatchTypes" onClick={onChooseStatisticsClick}>
-              매치 기록
-            </StatisticsSelectionButton>
-          </MatchResultsByMatchTypesList>
-          <MatchResultsByMatchTypesList>
-            <StatisticsSelectionButton type="button" name="TradeLog" onClick={onChooseStatisticsClick}>
-              이적시장 거래 목록
-            </StatisticsSelectionButton>
-          </MatchResultsByMatchTypesList>
-        </ChooseStatisticsUl>
+        <DescriptionDiv>
+          <DescriptionParagraph>매치 타입별 경기 데이터와 이적시장 기록 조회를 해 보세요.</DescriptionParagraph>
+        </DescriptionDiv>
 
-        {mode === 0 ? <MatchResultsByMatchTypes /> : <TradeLog />}
-        {/* <MatchResultsByMatchTypes />
-        <hr />
-        <TradeLog /> */}
+        <ContentDiv>
+          <MatchResultsByMatchTypes />
+          <TradeLog />
+        </ContentDiv>
       </MyRecordContainerDiv>
       <Footer page="MyRecord" />
     </>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4,6 +4,7 @@ export interface NexonUserInfo {
   level: number;
 }
 
+// 이런 데이터가 여러개 있으므로 ,사용할때 배열로 사용
 // {id: 101000250, name: "데이비드 베컴"}
 export interface MetaDataSpid {
   id: number;
@@ -114,7 +115,8 @@ export type matchInfoType = {
       tackle: number; // 태클 성공 수
       tackleTry: number; // 태글 시도 수
     };
-  }[];
+  }[]; // 위의 MetaDataSpid는 MetaDataSpid자체를 사용할 때 배열로 선언하면 되지만
+  // 이처럼 matchInfoType안의 특정 값들만 배열로 사용되고 있는 것은 여기서 직접 배열로 선언
 
   shoot: {
     // 해당 매치 전체 슛 정보

--- a/src/utils/MyRecord.ts
+++ b/src/utils/MyRecord.ts
@@ -33,3 +33,8 @@ export const convertDateAndTime = (dateStr: string) => {
   const minutes = date.getMinutes().toString().padStart(2, '0');
   return `${year}.${month}.${day} ${hours}:${minutes}`;
 };
+
+// 100000 >> 100,000
+export const addCommaonMoney = (money: number) => {
+  return money.toLocaleString('en-US');
+};


### PR DESCRIPTION
내 기록 페이지(MyRecord.tsx) 의 레이아웃을 변경합니다
각 매치 타입별 매치 결과들과 이적시장 기록들을 페이지 상위에 있는 버튼에 따라 하나씩 보여주었지만
매치 결과들과 이적시장 기록들을 한번에 보여주며 , 버튼 위치에는 페이지 소개 문구로 대체합니다