### PR TITLE
:sparkles: [#112][Feat] : 이적시장 목록 컴포넌트 뼈대 구현

### DIFF
--- a/src/Components/TradeLog/TradeLog.tsx
+++ b/src/Components/TradeLog/TradeLog.tsx
@@ -1,8 +1,65 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TradeLogContainerDiv } from './TradeLog.styled';
+import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
+import FIFAData from '../../Services/FifaData';
+import { TradeLogInfo } from '../../types/api';
+import { addCommaonMoney, convertDateAndTime } from '../../utils/MyRecord';
+import MatchResultsByMatchTypes from '../MatchResultsByMatchTypes';
+import PlayerImg from '../MatchStatistics/Player/PlayerImg';
 
 const TradeLog = () => {
-  return <TradeLogContainerDiv>이적시장 목록</TradeLogContainerDiv>;
+  const { userObj, setUserObj } = useUserObjAPI()!;
+
+  const [tradeInfo, setTradeInfo] = useState<{ buy: TradeLogInfo[]; sell: TradeLogInfo[] } | null>(null);
+  const [tradeType, setTradeType] = useState<'buy' | 'sell'>('buy');
+
+  // console.log(tradeInfo && tradeInfo[tradeType]);
+
+  useEffect(() => {
+    const test = async () => {
+      const fifa = new FIFAData();
+      const result = await fifa.getTradeLog(userObj!.FIFAOnlineAccessId);
+      setTradeInfo(result);
+    };
+    test();
+  }, []);
+
+  return (
+    <TradeLogContainerDiv>
+      <h2>이적 시장 목록</h2>
+
+      <div>
+        <table>
+          <thead>
+            <tr>
+              <th>BUY</th>
+              <th>SELL</th>
+            </tr>
+          </thead>
+        </table>
+      </div>
+
+      {tradeInfo && (
+        <div>
+          <table>
+            <tbody>
+              {tradeInfo[tradeType].map((i) => {
+                return (
+                  <tr key={i.saleSn}>
+                    {/* PlayerImg 폴더 위치 변경해야 할듯 */}
+                    <PlayerImg spId={i.spid} />
+                    <td>+{i.grade}</td>
+                    <td>{convertDateAndTime(i.tradeDate)}</td>
+                    <td>{addCommaonMoney(i.value)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </TradeLogContainerDiv>
+  );
 };
 
 export default TradeLog;

--- a/src/Services/FifaData.ts
+++ b/src/Services/FifaData.ts
@@ -8,6 +8,7 @@ import {
   MetaDataSpid,
   MetaDataSpposition,
   NexonUserInfo,
+  TradeLogInfo,
 } from '../types/api';
 
 export default class FIFAData {
@@ -38,6 +39,7 @@ export default class FIFAData {
   // <이미지 관련한 api는 필요할 때 직접 호출해서 사용합니다>
   // 상반신 미페
   getActionImg = async (spid: number): Promise<string> => {
+    // 프록시 사용
     const result = await axios.get(`/live/externalAssets/common/playersAction/p${spid}.png`, {
       headers: {
         Authorization: import.meta.env.REACT_APP_API_KEY_FIFA,
@@ -85,6 +87,16 @@ export default class FIFAData {
   getMatchDetail = async <T extends MatchDetail>(matchId: string): Promise<T> => {
     const result = await this.instance.get<T>(`matches/${matchId}`);
     return result.data;
+  };
+
+  // 이적시장 거래 목록
+  getTradeLog = async (accessid: string) => {
+    // return Promise.all([this.#getBuyTrageLog(accessid, 20), this.#getSellTrageLog(accessid, 20)]);
+    const tradeLog = {
+      buy: await this.#getBuyTrageLog(accessid, 20),
+      sell: await this.#getSellTrageLog(accessid, 20),
+    };
+    return tradeLog;
   };
 
   // 선수 spid
@@ -136,6 +148,29 @@ export default class FIFAData {
     const result = await axios.get<T[]>('https://static.api.nexon.co.kr/fifaonline4/latest/matchtype.json', {
       headers: {
         Authorization: import.meta.env.REACT_APP_API_KEY_FIFA,
+      },
+    });
+
+    return result.data;
+  };
+
+  // /users/{accessid}/markets?tradetype={tradetype}&offset={offset}&limit={limit}
+  #getBuyTrageLog = async <T extends TradeLogInfo>(accessid: string, limit: number): Promise<T[]> => {
+    const result = await this.instance.get<T[]>(`/users/${accessid}/markets`, {
+      params: {
+        tradetype: 'buy',
+        limit,
+      },
+    });
+
+    return result.data;
+  };
+
+  #getSellTrageLog = async <T extends TradeLogInfo>(accessid: string, limit: number): Promise<T[]> => {
+    const result = await this.instance.get<T[]>(`/users/${accessid}/markets`, {
+      params: {
+        tradetype: 'sell',
+        limit,
       },
     });
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -168,3 +168,16 @@ export interface MatchDetail {
   matchType: number;
   matchInfo: [matchInfoType, matchInfoType]; // 길이가 고정적이므로 튜플 사용
 }
+
+// { "tradeDate": "2023-05-31T01:07:25",
+// "saleSn": "64761f3cad134d6873034f84",
+// "spid": 265204024,
+// "grade": 1,
+// "value": 499000000 }
+export interface TradeLogInfo {
+  tradeDate: string;
+  saleSn: string;
+  spid: number;
+  grade: number;
+  value: number;
+}


### PR DESCRIPTION
내 기록 페이지(MyRecord.tsx)에 사용되는 이적시장 목록 컴포넌트(TradeLog.tsx)의 뼈대를 구현하고 관련 데이터들이 제대로 렌더링 되는지 확인합니다