### PR TITLE
:bug: [#125][Feat] : Footer의 레이아웃 깨짐 현상 해결

### DIFF
--- a/src/Components/Footer/Footer.styled.ts
+++ b/src/Components/Footer/Footer.styled.ts
@@ -21,13 +21,13 @@ export const ContactAndGitHubDiv = styled.div`
   display: flex;
 `;
 export const ContactDiv = styled.div`
-  padding-right: 15%;
+  padding-right: 3em;
   font-size: 1rem;
   color: gray;
 `;
 
 export const GitHubDiv = styled.div`
-  padding-left: 15%;
+  padding-left: 3em;
   font-size: 1rem;
   color: gray;
 `;


### PR DESCRIPTION
페이지의 너비를 줄이다 보면 일정 부분 이하부터 Footer의 width가 페이지 전체를 뚫고 나오는 현상을 해결합니다