### PR TITLE
:sparkles: [#130][Feat] : 내 기록 페이지 매치 데이터 조회 부재 문구 위치 수정

### DIFF
--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
@@ -74,7 +74,7 @@ export const TableContentDiv = styled.div`
   margin-top: 0px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   ::-webkit-scrollbar {
-    width: 8px;
+    width: 5px;
   }
 
   ::-webkit-scrollbar-thumb {
@@ -164,4 +164,13 @@ export const LoadingDiv = styled.div`
   justify-content: center;
   align-items: center;
   height: 35em; // 기존 테이블과 높이 통일
+`;
+
+export const NotFoundMatchDataDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 35em; // 기존 테이블과 높이 통일
+  font-size: 1.2rem;
+  font-weight: bolder;
 `;

--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.tsx
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.tsx
@@ -8,6 +8,7 @@ import {
   LoadingDiv,
   MatchLengthBuuton,
   MatchResultsByMatchTypesContainer,
+  NotFoundMatchDataDiv,
   Table,
   TableContentDiv,
   TableHeaderDiv,
@@ -211,7 +212,7 @@ const MatchResultsByMatchTypes = () => {
         </TableContentDiv>
       ) : // matchDetail가 빈 배열이라면 로딩중 이거나 matchId값이 없어서(=기록 자체가 없음) useEffect에서 빈 배열로 처리된 것이다
       matchId.length === 0 ? (
-        <div>해당 매치 기록이 존재하지 않습니다</div>
+        <NotFoundMatchDataDiv>해당 매치 기록이 존재하지 않습니다</NotFoundMatchDataDiv>
       ) : (
         <LoadingDiv>
           <Loading />

--- a/src/Components/Navbar/Navbar.tsx
+++ b/src/Components/Navbar/Navbar.tsx
@@ -41,7 +41,7 @@ const Navbar = ({ scrollPoint, page }: NavBarProps) => {
       </NavMenuUl>
 
       <NavIconsUl>
-        <NavIconsList>SNS</NavIconsList>
+        <NavIconsList>src</NavIconsList>
       </NavIconsUl>
     </Nav>
   );


### PR DESCRIPTION
내 기록 페이지의 매치 타입 별 데이터를 조회하는 컴포넌트( MatchResultsByMatchTypes.tsx ) 에서 해당 매치 타입의 데이터가 없을시 발생하는 문구의 위치를 수정합니다