### PR TITLE
:sparkles: [#134][Feat] : 매치 통계 페이지 기본 레이아웃 지정

### DIFF
--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
@@ -57,6 +57,7 @@ export const Table = styled.table`
   border: 0;
   padding: 0;
   border-spacing: 0;
+
   /* cellpadding : "0"; 
   cellspacing : "0" ; */
 `;
@@ -64,15 +65,16 @@ export const Table = styled.table`
 export const TableHeaderDiv = styled.div`
   margin-top: 3%;
   border-top: 5px solid black;
+  box-shadow: 10px 0 5px -2px rgba(0, 0, 0, 0.2), -10px 0 5px -2px rgba(0, 0, 0, 0.2);
 `;
 
 export const TableContentDiv = styled.div`
   // height: 500px;
   height: 35em;
-
   overflow-x: auto;
   margin-top: 0px;
   border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 10px 0 5px -2px rgba(0, 0, 0, 0.2), -10px 0 5px -2px rgba(0, 0, 0, 0.2);
   ::-webkit-scrollbar {
     width: 5px;
   }

--- a/src/Components/Statistics/Statistics.styled.ts
+++ b/src/Components/Statistics/Statistics.styled.ts
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+export const StatisticsContainerDiv = styled.div``;
+
+export const OutlineHeading = styled.h2`
+  margin-top: 2em;
+`;
+
+export const OutlineUl = styled.ul`
+  list-style: none;
+  li {
+    margin: 1.2em 0;
+    font-size: 1.2rem;
+    display: flex;
+    justify-content: space-between;
+  }
+  width: 50%;
+  margin: 0 auto;
+  padding-bottom: 10%;
+  border-bottom: 1px solid lightgray;
+`;
+
+export const DataNotExistDiv = styled.div`
+  height: 19em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: red;
+  font-size: 1.3rem;
+  font-weight: bolder;
+`;
+
+export const DetailStatisticsDiv = styled.div`
+  margin-top: 5%;
+`;
+
+export const DetailStatisticsUl = styled.ul`
+  padding-left: 0;
+  margin-top: 5%;
+  list-style: none;
+  display: flex;
+  justify-content: space-around;
+  button {
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 1.3rem;
+  }
+`;
+
+export const StatisticsContentDiv = styled.div``;

--- a/src/Components/Statistics/Statistics.tsx
+++ b/src/Components/Statistics/Statistics.tsx
@@ -3,6 +3,15 @@ import Defence from './Defence';
 import Pass from './Pass';
 import Player from './Player';
 import Shoot from './Shoot';
+import {
+  DataNotExistDiv,
+  DetailStatisticsDiv,
+  DetailStatisticsUl,
+  OutlineHeading,
+  OutlineUl,
+  StatisticsContainerDiv,
+  StatisticsContentDiv,
+} from './Statistics.styled';
 import { MatchStatisticsProps } from '../../types/props';
 import { convertYardtoMeter } from '../../utils/MatchStatistics';
 
@@ -10,6 +19,7 @@ const Statistics = ({ matchDetail, myDataIndex, selectedUsertStatistics }: Match
   const [statisticsMode, setStatisticsMode] = useState('defence');
 
   console.log(matchDetail.matchInfo[selectedUsertStatistics]);
+  console.log(matchDetail.matchInfo[selectedUsertStatistics].matchDetail.matchEndType);
 
   const onModeClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const { name, value } = e.currentTarget;
@@ -46,42 +56,80 @@ const Statistics = ({ matchDetail, myDataIndex, selectedUsertStatistics }: Match
     return matchDetail.matchInfo[selectedUsertStatistics].shootDetail;
   };
   return (
-    <div>
-      <div>전체 정보</div>
+    <StatisticsContainerDiv>
+      <OutlineHeading>기본 정보</OutlineHeading>
 
-      <ul>
-        {/* <li>선수 평균 평점 : {shortCutMathchDetail().averageRating.toFixed(1)}</li> */}
-        <li>사용 컨트롤러 : {shortCutMathchDetail().controller}</li>
-        <li>점유율 : {shortCutMathchDetail().possession}%</li>
-        <li>코너킥 수 : {shortCutMathchDetail().cornerKick}</li>
-        <li>평균 드리블 거리 : {convertYardtoMeter(shortCutMathchDetail().dribble)}m</li>
-        <li>파울 : {shortCutMathchDetail().foul}</li>
-        <li>옐로 카드 : {shortCutMathchDetail().yellowCards}</li>
-        <li>레드 카드 : {shortCutMathchDetail().redCards}</li>
-        <li>부상 : {shortCutMathchDetail().injury}</li>
-        <li>오프사이드 : {shortCutMathchDetail().offsideCount}</li>
-      </ul>
+      {matchDetail.matchInfo[selectedUsertStatistics].matchDetail.matchEndType === 2 ? (
+        <DataNotExistDiv>몰수패는 데이터가 집계되지 않습니다</DataNotExistDiv>
+      ) : (
+        <OutlineUl>
+          <li>
+            <span>사용 컨트롤러 &nbsp; : </span>
+            {shortCutMathchDetail().controller}
+          </li>
+          <li>
+            <span>점유율 &nbsp; :</span> {shortCutMathchDetail().possession}%
+          </li>
+          <li>
+            <span>코너킥 수 &nbsp; :</span> {shortCutMathchDetail().cornerKick}
+          </li>
+          <li>
+            <span>평균 드리블 거리 &nbsp; :</span> {convertYardtoMeter(shortCutMathchDetail().dribble)}m
+          </li>
+          <li>
+            <span>파울 &nbsp; : </span>
+            {shortCutMathchDetail().foul}
+          </li>
+          <li>
+            <span>카드 ( 옐로 / 레드 ) &nbsp; :</span> ( {shortCutMathchDetail().yellowCards} / {shortCutMathchDetail().redCards} )
+          </li>
+          <li>
+            <span>부상 &nbsp; : </span>
+            {shortCutMathchDetail().injury}
+          </li>
+          <li>
+            <span>오프사이드 &nbsp; :</span> {shortCutMathchDetail().offsideCount}
+          </li>
+        </OutlineUl>
+      )}
 
-      <div>
-        <button type="button" name="defence" onClick={onModeClick} value="defence">
-          수비
-        </button>
-        <button type="button" name="pass" onClick={onModeClick} value="pass">
-          패스
-        </button>
-        <button type="button" name="shoot" onClick={onModeClick} value="shoot">
-          슈팅
-        </button>
-        <button type="button" name="player" onClick={onModeClick} value="player">
-          선수
-        </button>
-      </div>
+      <DetailStatisticsDiv>
+        <h2>세부 정보</h2>
+        <DetailStatisticsUl>
+          <li>
+            <button type="button" name="defence" onClick={onModeClick} value="defence">
+              수비
+            </button>
+          </li>
+          <li>
+            <button type="button" name="pass" onClick={onModeClick} value="pass">
+              패스
+            </button>
+          </li>
+          <li>
+            <button type="button" name="shoot" onClick={onModeClick} value="shoot">
+              슈팅
+            </button>
+          </li>
+          <li>
+            <button type="button" name="player" onClick={onModeClick} value="player">
+              선수
+            </button>
+          </li>
+        </DetailStatisticsUl>
 
-      {statisticsMode === 'defence' && <Defence shortCutDefence={shortCutDefence} />}
-      {statisticsMode === 'pass' && <Pass shortCutPass={shortCutPass} />}
-      {statisticsMode === 'shoot' && <Shoot shortCutShoot={shortCutShoot} shortCutShootDetail={shortCutShootDetail} />}
-      {statisticsMode === 'player' && <Player shortCutPlayer={shortCutPlayer} />}
-    </div>
+        {matchDetail.matchInfo[selectedUsertStatistics].matchDetail.matchEndType === 2 ? (
+          <DataNotExistDiv>몰수패는 데이터가 집계되지 않습니다</DataNotExistDiv>
+        ) : (
+          <StatisticsContentDiv>
+            {statisticsMode === 'defence' && <Defence shortCutDefence={shortCutDefence} />}
+            {statisticsMode === 'pass' && <Pass shortCutPass={shortCutPass} />}
+            {statisticsMode === 'shoot' && <Shoot shortCutShoot={shortCutShoot} shortCutShootDetail={shortCutShootDetail} />}
+            {statisticsMode === 'player' && <Player shortCutPlayer={shortCutPlayer} />}
+          </StatisticsContentDiv>
+        )}
+      </DetailStatisticsDiv>
+    </StatisticsContainerDiv>
   );
 };
 

--- a/src/Components/TradeLog/TradeLog.styled.ts
+++ b/src/Components/TradeLog/TradeLog.styled.ts
@@ -67,6 +67,7 @@ export const TableContentDiv = styled.div`
   overflow-x: auto;
   margin-top: 0px;
   border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 10px 0 5px -2px rgba(0, 0, 0, 0.2), -10px 0 5px -2px rgba(0, 0, 0, 0.2);
   ::-webkit-scrollbar {
     width: 5px;
   }

--- a/src/Pages/MatchStatistics/MatchStatistics.styled.ts
+++ b/src/Pages/MatchStatistics/MatchStatistics.styled.ts
@@ -1,0 +1,80 @@
+import styled from 'styled-components';
+import { NickNameProps } from '../../types/props';
+
+export const MatchStatisticsContainerDiv = styled.div`
+  width: 70%;
+  margin: 0 auto;
+
+  /* // 1400px 이하일때는 970px로 고정
+  @media (max-width: 1400px) {
+    min-width: 970px;
+  }
+
+  // 그러다가 1024px이하일때는 레이아웃을 변경하기 때문에 (하나씩 세로로 보여줌)
+  // 기존대로 70%
+  @media (max-width: 1024px) {
+    width: 70%;
+  } */
+`;
+
+export const PlayerNickNames = styled.div`
+  display: flex;
+  height: 5em;
+  justify-content: space-around;
+  align-items: flex-end;
+  margin-top: 4em;
+
+  button {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    min-width: 280px;
+    overflow: hidden;
+    padding: 19.92px 0;
+    &:hover {
+      transform: translateY(-5px);
+    }
+    transition: transform 0.3s ease;
+  }
+  /* span {
+    font-size: 1.8rem;
+    font-weight: bolder;
+    margin: 5%;
+  } */
+`;
+
+export const NickNameSpan = styled.span<NickNameProps>`
+  border-bottom: ${(props) => (props.myDataIndex === props.selectedUsertStatistics ? '1px solid black' : 'none')};
+  padding-bottom: 10px;
+  font-size: 1.8rem;
+  font-weight: bolder;
+`;
+
+export const ScoresAndTimeDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-bottom: 1px solid lightgray;
+`;
+
+export const ScoresDiv = styled.div`
+  display: flex;
+  margin-top: 40px;
+  padding-bottom: 2.7em;
+  font-size: 2rem;
+  h2 {
+    margin: 0;
+  }
+`;
+
+export const TimeDiv = styled.div`
+  font-size: 1.2rem;
+  color: gray;
+`;
+
+export const LoadingDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+`;

--- a/src/Pages/MatchStatistics/MatchStatistics.tsx
+++ b/src/Pages/MatchStatistics/MatchStatistics.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  LoadingDiv,
+  MatchStatisticsContainerDiv,
+  NickNameSpan,
+  PlayerNickNames,
+  ScoresAndTimeDiv,
+  ScoresDiv,
+  TimeDiv,
+} from './MatchStatistics.styled';
 import Footer from '../../Components/Footer';
 import Loading from '../../Components/Loading';
 import Navbar from '../../Components/Navbar';
@@ -8,6 +17,7 @@ import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
 import FIFAData from '../../Services/FifaData';
 import { MatchDetail } from '../../types/api';
 import { myDataIndex, selectedUsertStatistics } from '../../types/states';
+import { convertDateAndTime } from '../../utils/MyRecord';
 
 const MatchStatistics = () => {
   const { matchId } = useParams();
@@ -43,58 +53,57 @@ const MatchStatistics = () => {
     }
     setSelectedUsertStatistics(index);
   };
+  console.log(selectedUsertStatistics);
 
   const showResultWithScore = (index: 0 | 1): React.ReactNode => {
     if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 1) {
-      return <h2>몰수 승</h2>;
+      return <h2>몰수 승 ({matchDetail?.matchInfo[index].shoot.goalTotal}) </h2>;
     }
 
     if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 2) {
-      return <h2>몰수 패</h2>;
+      return <h2>({matchDetail?.matchInfo[index].shoot.goalTotal}) 몰수 패 </h2>;
     }
     return <h2>{matchDetail?.matchInfo[index].shoot.goalTotalDisplay}</h2>;
   };
 
   if (!(matchDetail && myDataIndex)) {
-    return <Loading />;
+    return (
+      <LoadingDiv>
+        <Loading />
+      </LoadingDiv>
+    );
   }
+  console.log(matchDetail);
   return (
     <>
       <Navbar page="MatchResultWithMatchStatistics" />
-      <div>
-        <div style={{ display: 'flex' }}>
+      <MatchStatisticsContainerDiv>
+        <PlayerNickNames>
           <button type="button" onClick={() => onUserNicknameClick('mine')}>
-            {matchDetail.matchInfo[myDataIndex!.mine].nickname}
+            <NickNameSpan myDataIndex={myDataIndex.mine} selectedUsertStatistics={selectedUsertStatistics}>
+              {matchDetail.matchInfo[myDataIndex!.mine].nickname}
+            </NickNameSpan>
           </button>
-          <h1>vs</h1>
+          <h2>vs</h2>
           <button type="button" onClick={() => onUserNicknameClick('other')}>
-            {matchDetail.matchInfo[myDataIndex!.other].nickname}
+            <NickNameSpan myDataIndex={myDataIndex.other} selectedUsertStatistics={selectedUsertStatistics}>
+              {matchDetail.matchInfo[myDataIndex!.other].nickname}
+            </NickNameSpan>
           </button>
-        </div>
-        <div style={{ display: 'flex' }}>
-          {/* {matchDetail?.matchInfo[myDataIndex!.mine].matchDetail.matchEndType === 0 ? (
-          <h2>{matchDetail?.matchInfo[myDataIndex!.mine].shoot.goalTotalDisplay}</h2>
-        ) : matchDetail?.matchInfo[myDataIndex!.mine].matchDetail.matchEndType === 1 ? (
-          <h2>몰수 승</h2>
-        ) : (
-          <h2>몰수 패</h2>
-        )} */}
-          {showResultWithScore(myDataIndex.mine)}
-
-          <h2> : </h2>
-
-          {/* {matchDetail?.matchInfo[myDataIndex!.other].matchDetail.matchEndType === 0 ? (
-          <h2>{matchDetail?.matchInfo[myDataIndex!.other].shoot.goalTotalDisplay}</h2>
-        ) : matchDetail?.matchInfo[myDataIndex!.other].matchDetail.matchEndType === 1 ? (
-          <h2>몰수 승</h2>
-        ) : (
-          <h2>몰수 패</h2>
-        )} */}
-          {showResultWithScore(myDataIndex.other)}
-        </div>
+        </PlayerNickNames>
+        <ScoresAndTimeDiv>
+          <ScoresDiv>
+            {showResultWithScore(myDataIndex.mine)}
+            &nbsp;&nbsp;<h2>:</h2>&nbsp;&nbsp;
+            {showResultWithScore(myDataIndex.other)}
+          </ScoresDiv>
+          <TimeDiv>
+            <p>{convertDateAndTime(matchDetail.matchDate)}</p>
+          </TimeDiv>
+        </ScoresAndTimeDiv>
 
         <Statistics matchDetail={matchDetail} myDataIndex={myDataIndex} selectedUsertStatistics={selectedUsertStatistics} />
-      </div>
+      </MatchStatisticsContainerDiv>
       <Footer page="MatchResultWithMatchStatistics" />
     </>
   );

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -52,3 +52,8 @@ export interface MatchLengthProps {
   matchLength: number;
   variant: number;
 }
+
+export interface NickNameProps {
+  myDataIndex: number;
+  selectedUsertStatistics: number;
+}


### PR DESCRIPTION
매치 통계를 보여주는 MatchStatistics.tsx 페이지의 기본 레이아웃 및 디자인을 적용합니다. 또한 , 몰수 패/몰수 승의 경우, 몰수 승을 거둔 상대방의 실제 점수까지 보여주며 몰수 패를 당한 유저의 데이터는 집계가 되지 않으므로 유저에게 해당 문구를 보여줍니다