### PR TITLE
:recycle: [#149][Refactor] : 불필요하게 중복되는 코드 리팩토링

### DIFF
--- a/src/Components/Statistics/Defence/Defence.tsx
+++ b/src/Components/Statistics/Defence/Defence.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DefenceContainerDiv, ForfeitDiv } from './Defence.styled';
-import { DefenceProps, MatchInfos } from '../../../types/props';
+import { MatchInfos } from '../../../types/props';
 import { calculatePercent } from '../../../utils/MatchStatistics';
 import Forfeit from '../../Forfeit';
 

--- a/src/Components/Statistics/Pass/Pass.tsx
+++ b/src/Components/Statistics/Pass/Pass.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PassContainerDiv } from './Pass.styled';
-import { MatchInfos, PassProps } from '../../../types/props';
+import { MatchInfos } from '../../../types/props';
 import { calculatePercent } from '../../../utils/MatchStatistics';
 import Forfeit from '../../Forfeit';
 

--- a/src/Components/Statistics/Player/Player.tsx
+++ b/src/Components/Statistics/Player/Player.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { PlayerContainerDiv } from './Player.styled';
 import FIFAData from '../../../Services/FifaData';
-import { MatchInfos, PlayerProps } from '../../../types/props';
+import { MatchInfos } from '../../../types/props';
 import { convertPlayerName, convertPosition, convertYardtoMeter, getSeasonImg } from '../../../utils/MatchStatistics';
 import Forfeit from '../../Forfeit';
 import PlayerImg from '../../PlayerImg';

--- a/src/Components/Statistics/Shoot/Shoot.tsx
+++ b/src/Components/Statistics/Shoot/Shoot.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ShootContainerDiv } from './Shoot.styled';
-import { MatchInfos, ShootProps } from '../../../types/props';
+import { MatchInfos } from '../../../types/props';
 import { calculateGoalTime } from '../../../utils/MatchStatistics';
 import Forfeit from '../../Forfeit';
 

--- a/src/Components/Statistics/Statistics.tsx
+++ b/src/Components/Statistics/Statistics.tsx
@@ -16,13 +16,13 @@ import {
 import { MatchStatisticsProps } from '../../types/props';
 import { convertYardtoMeter } from '../../utils/MatchStatistics';
 
-const Statistics = ({ matchDetail, myDataIndex, selectedUsertStatistics }: MatchStatisticsProps) => {
+const Statistics = ({ myMatchInfo, otherMatchInfo }: MatchStatisticsProps) => {
   const [statisticsMode, setStatisticsMode] = useState('defence');
 
-  const [myMatch, otherMatch] = [matchDetail.matchInfo[myDataIndex.mine], matchDetail.matchInfo[myDataIndex.other]];
-  const [myNickName, otherNickName] = [myMatch.nickname, otherMatch.nickname];
+  // const [myMatch, otherMatch] = [matchDetail.matchInfo[myDataIndex.mine], matchDetail.matchInfo[myDataIndex.other]];
+  const [myNickName, otherNickName] = [myMatchInfo.nickname, otherMatchInfo.nickname];
 
-  const [myMatchDetail, otherMatchDetail] = [myMatch.matchDetail, otherMatch.matchDetail];
+  const [myMatchDetail, otherMatchDetail] = [myMatchInfo.matchDetail, otherMatchInfo.matchDetail];
   const myMatchDetailBasic = [
     myMatchDetail.possession,
     convertYardtoMeter(myMatchDetail.dribble),
@@ -172,10 +172,10 @@ const Statistics = ({ matchDetail, myDataIndex, selectedUsertStatistics }: Match
         {/* <DataNotExistDiv>몰수패는 데이터가 집계되지 않습니다</DataNotExistDiv> */}
 
         <StatisticsContentDiv>
-          {statisticsMode === 'defence' && <Defence matchInfos={[myMatch, otherMatch]} />}
-          {statisticsMode === 'pass' && <Pass matchInfos={[myMatch, otherMatch]} />}
-          {statisticsMode === 'shoot' && <Shoot matchInfos={[myMatch, otherMatch]} />}
-          {statisticsMode === 'player' && <Player matchInfos={[myMatch, otherMatch]} />}
+          {statisticsMode === 'defence' && <Defence matchInfos={[myMatchInfo, otherMatchInfo]} />}
+          {statisticsMode === 'pass' && <Pass matchInfos={[myMatchInfo, otherMatchInfo]} />}
+          {statisticsMode === 'shoot' && <Shoot matchInfos={[myMatchInfo, otherMatchInfo]} />}
+          {statisticsMode === 'player' && <Player matchInfos={[myMatchInfo, otherMatchInfo]} />}
         </StatisticsContentDiv>
       </DetailStatisticsDiv>
     </StatisticsContainerDiv>

--- a/src/Pages/MatchStatistics/MatchStatistics.tsx
+++ b/src/Pages/MatchStatistics/MatchStatistics.tsx
@@ -19,7 +19,7 @@ import Statistics from '../../Components/Statistics';
 import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
 import FIFAData from '../../Services/FifaData';
 import goalImg from '../../images/goalImg.jpg';
-import { MatchDetail } from '../../types/api';
+import { MatchDetail, matchInfoType } from '../../types/api';
 import { myDataIndex, selectedUsertStatistics } from '../../types/states';
 import { convertPlayerName, extractGoalInfo } from '../../utils/MatchStatistics';
 import { convertDateAndTime } from '../../utils/MyRecord';
@@ -29,22 +29,34 @@ const MatchStatistics = () => {
   const [matchDetail, setMatchDetail] = useState<MatchDetail | null>(null); // 한 매치의 전체 데이터
   const [myDataIndex, setMyDataIndex] = useState<myDataIndex | null>(null); // 로그인 한 유저의 데이터 인덱스 (1대1 이므로 matchDetail.matchInfo[0] 아니면 matchDetail.matchInfo[1])
   const { userObj, setUserObj } = useUserObjAPI()!;
-  const [selectedUsertStatistics, setSelectedUsertStatistics] = useState<selectedUsertStatistics>(0); // 유저의 이름을 클릭함에 따라 보여줄 데이터의 인덱스 (1대1 이므로 matchDetail.matchInfo[0] 아니면 matchDetail.matchInfo[1])
-  // const [];
+
+  // 추가적인 기능은 없으나 , 추후 코드가 길어지는 것을 방지하기 위해
+  // 변수형태로 간결하게 사용할 목적으로 선언
+  const [myMatchInfo, setMyMatchInfo] = useState<matchInfoType | null>(null);
+  const [otherMatchInfo, setOtherMatchInfo] = useState<matchInfoType | null>(null);
+
+  // 유저의 이름을 클릭함에 따라 보여줄 데이터의 인덱스 (1대1 이므로 matchDetail.matchInfo[0] 아니면 matchDetail.matchInfo[1])
+  // 현재는 사용중이지 않지만 추후 쓰일 수 있으므로 유지
+  const [selectedUsertStatistics, setSelectedUsertStatistics] = useState<selectedUsertStatistics>(0);
 
   useEffect(() => {
     // 최초에 api를 불러와서 데이터 세팅
     const getMatchDetail = async () => {
       const fifa = new FIFAData();
-      const result = await fifa.getMatchDetail(matchId!);
+      const matchDetailResult = await fifa.getMatchDetail(matchId!);
       let indexInfo = {} as myDataIndex; // 확실한 상황이므로 type assertion 사용
 
       // matchDetail.matchInfo[0]이 현재 로그인한 계정이라면
-      result.matchInfo[0].accessId === userObj?.FIFAOnlineAccessId ? (indexInfo = { mine: 0, other: 1 }) : (indexInfo = { mine: 1, other: 0 });
+      matchDetailResult.matchInfo[0].accessId === userObj?.FIFAOnlineAccessId
+        ? (indexInfo = { mine: 0, other: 1 })
+        : (indexInfo = { mine: 1, other: 0 });
 
       setMyDataIndex(indexInfo);
-      setMatchDetail(result);
+      setMatchDetail(matchDetailResult);
       setSelectedUsertStatistics(indexInfo.mine); // 디폴트로 자기 자신의 정보를 보여줌
+
+      setMyMatchInfo(matchDetailResult.matchInfo[indexInfo.mine]);
+      setOtherMatchInfo(matchDetailResult.matchInfo[indexInfo.other]);
     };
     getMatchDetail();
   }, []);
@@ -60,23 +72,61 @@ const MatchStatistics = () => {
     setSelectedUsertStatistics(index);
   };
 
-  const showResultWithScore = (index: 0 | 1): React.ReactNode => {
-    if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 1) {
-      return (
-        <p>
-          몰수승<span>({matchDetail?.matchInfo[index].shoot.goalTotal})</span>
-        </p>
-      );
+  const showResultWithScore = (target: string): React.ReactNode => {
+    // if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 1) {
+    //   return (
+    //     <p>
+    //       몰수승<span>({matchDetail?.matchInfo[index].shoot.goalTotal})</span>
+    //     </p>
+    //   );
+    // }
+    // if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 2) {
+    //   return (
+    //     <p>
+    //       <span>({matchDetail?.matchInfo[index].shoot.goalTotal})</span>몰수패
+    //     </p>
+    //   );
+    // }
+    // return <p>{matchDetail?.matchInfo[index].shoot.goalTotalDisplay}</p>;
+
+    if (target === 'mine') {
+      if (myMatchInfo?.matchDetail.matchEndType === 1) {
+        return (
+          <p>
+            몰수승<span>({myMatchInfo.shoot.goalTotal})</span>
+          </p>
+        );
+      }
+      if (myMatchInfo?.matchDetail.matchEndType === 2) {
+        return (
+          <p>
+            몰수패<span>({myMatchInfo.shoot.goalTotal})</span>
+          </p>
+        );
+      }
+      return <p>{myMatchInfo?.shoot.goalTotalDisplay}</p>;
     }
 
-    if (matchDetail?.matchInfo[index].matchDetail.matchEndType === 2) {
-      return (
-        <p>
-          <span>({matchDetail?.matchInfo[index].shoot.goalTotal})</span>몰수패
-        </p>
-      );
+    if (target === 'other') {
+      if (otherMatchInfo?.matchDetail.matchEndType === 1) {
+        return (
+          <p>
+            <span>({otherMatchInfo.shoot.goalTotal})몰수승</span>
+          </p>
+        );
+      }
+      if (otherMatchInfo?.matchDetail.matchEndType === 2) {
+        return (
+          <p>
+            <span>({otherMatchInfo.shoot.goalTotal})몰수패</span>
+          </p>
+        );
+      }
+      return <p>{otherMatchInfo?.shoot.goalTotalDisplay}</p>;
     }
-    return <p>{matchDetail?.matchInfo[index].shoot.goalTotalDisplay}</p>;
+
+    // eslint 에러 방지용
+    return <></>;
   };
 
   if (!(matchDetail && myDataIndex)) {
@@ -92,26 +142,27 @@ const MatchStatistics = () => {
   return (
     <>
       {/* matchDetail 과 myDataIndex가 로딩되지 않으면 로딩인디케이터를 띄워주기 때문에
-     여기선 조건부 렌더링을 사용할 필요 없이 바로 matchDetail 와 myDataIndex를 사용 */}
+     여기선 조건부 렌더링을 사용할 필요 없이 바로 matchDetail 와 myDataIndex를 사용할 수 있으며
+     non-null assertion또한 자유롭게 사용 가능 */}
       <Navbar page="MatchStatistics" />
       <MatchStatisticsContainerDiv>
         <PlayerNickNames>
           <button type="button" onClick={() => onUserNicknameClick('mine')}>
             <NickNameSpan myDataIndex={myDataIndex.mine} selectedUsertStatistics={selectedUsertStatistics}>
-              {matchDetail.matchInfo[myDataIndex!.mine].nickname}
+              {myMatchInfo!.nickname}
             </NickNameSpan>
           </button>
           <h2>vs</h2>
           <button type="button" onClick={() => onUserNicknameClick('other')}>
             <NickNameSpan myDataIndex={myDataIndex.other} selectedUsertStatistics={selectedUsertStatistics}>
-              {matchDetail.matchInfo[myDataIndex!.other].nickname}
+              {otherMatchInfo!.nickname}
             </NickNameSpan>
           </button>
         </PlayerNickNames>
         <MatchScoreAndTimes>
           <ScoresAndGoalTime>
             <MyGoalTime>
-              {extractGoalInfo(matchDetail.matchInfo[myDataIndex.mine].shootDetail).map((i, index) => {
+              {extractGoalInfo(myMatchInfo!.shootDetail).map((i, index) => {
                 return (
                   <li key={index}>
                     <img src={goalImg} alt="goalImg" width="18" />
@@ -119,15 +170,17 @@ const MatchStatistics = () => {
                   </li>
                 );
               })}
-              {matchDetail.matchInfo[myDataIndex.mine].shoot.ownGoal !== 0 && <>자살골</>}
+              {myMatchInfo!.shoot.ownGoal !== 0 && <>자살골</>}
             </MyGoalTime>
             <Scores>
-              <span>{showResultWithScore(myDataIndex.mine)}</span>
+              {/* <span>{showResultWithScore(myDataIndex.mine)}</span> */}
+              <span>{showResultWithScore('mine')}</span>
               &nbsp;&nbsp;<h2>:</h2>&nbsp;&nbsp;
-              <span>{showResultWithScore(myDataIndex.other)}</span>
+              {/* <span>{showResultWithScore(myDataIndex.other)}</span> */}
+              <span>{showResultWithScore('other')}</span>
             </Scores>
             <OtherGoalTime>
-              {extractGoalInfo(matchDetail.matchInfo[myDataIndex.other].shootDetail).map((i, index) => {
+              {extractGoalInfo(otherMatchInfo!.shootDetail).map((i, index) => {
                 return (
                   <li key={index}>
                     <img src={goalImg} alt="goalImg" width="18" />
@@ -135,7 +188,7 @@ const MatchStatistics = () => {
                   </li>
                 );
               })}
-              {matchDetail.matchInfo[myDataIndex.other].shoot.ownGoal !== 0 && <>자살골</>}
+              {otherMatchInfo!.shoot.ownGoal !== 0 && <>자살골</>}
             </OtherGoalTime>
           </ScoresAndGoalTime>
           <MatchTimeDiv>
@@ -143,7 +196,8 @@ const MatchStatistics = () => {
           </MatchTimeDiv>
         </MatchScoreAndTimes>
 
-        <Statistics matchDetail={matchDetail} myDataIndex={myDataIndex} selectedUsertStatistics={selectedUsertStatistics} />
+        {/* <Statistics matchDetail={matchDetail} myDataIndex={myDataIndex} selectedUsertStatistics={selectedUsertStatistics} /> */}
+        <Statistics myMatchInfo={myMatchInfo!} otherMatchInfo={otherMatchInfo!} />
       </MatchStatisticsContainerDiv>
       <Footer page="MatchStatistics" />
     </>

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -2,32 +2,34 @@ import { MatchDetail, matchInfoType } from './api';
 import { myDataIndex, selectedUsertStatistics } from './states';
 
 export interface MatchStatisticsProps {
-  matchDetail: MatchDetail;
-  myDataIndex: myDataIndex;
-  selectedUsertStatistics: selectedUsertStatistics;
+  // matchDetail: MatchDetail;
+  // myDataIndex: myDataIndex;
+  // selectedUsertStatistics: selectedUsertStatistics;
+  myMatchInfo: matchInfoType;
+  otherMatchInfo: matchInfoType;
 }
 
 export interface MatchInfos {
-  matchInfos: MatchDetail['matchInfo'][0][];
+  matchInfos: matchInfoType[];
 }
 
-export interface DefenceProps {
-  //  MatchDetail['matchInfo'][0]['defence'] 형태의 데이터가 담긴 배열이므로 뒤에 []사용
-  shortCutDefence: () => MatchDetail['matchInfo'][0]['defence'][];
-}
+// export interface DefenceProps {
+//   //  MatchDetail['matchInfo'][0]['defence'] 형태의 데이터가 담긴 배열이므로 뒤에 []사용
+//   shortCutDefence: () => MatchDetail['matchInfo'][0]['defence'][];
+// }
 
-export interface PassProps {
-  shortCutPass: () => MatchDetail['matchInfo'][0]['pass'][];
-}
+// export interface PassProps {
+//   shortCutPass: () => MatchDetail['matchInfo'][0]['pass'][];
+// }
 
-export interface PlayerProps {
-  shortCutPlayer: () => MatchDetail['matchInfo'][0]['player'][];
-}
+// export interface PlayerProps {
+//   shortCutPlayer: () => MatchDetail['matchInfo'][0]['player'][];
+// }
 
-export interface ShootProps {
-  shortCutShoot: () => MatchDetail['matchInfo'][0]['shoot'][];
-  shortCutShootDetail: () => MatchDetail['matchInfo'][0]['shootDetail'][];
-}
+// export interface ShootProps {
+//   shortCutShoot: () => MatchDetail['matchInfo'][0]['shoot'][];
+//   shortCutShootDetail: () => MatchDetail['matchInfo'][0]['shootDetail'][];
+// }
 
 export interface PlayerImgProps {
   spId: number;


### PR DESCRIPTION
MatchStatistics 페이지와 Statistics 하위 컴포넌트에 전반적으로 사용중인 매치 정보 데이터를 사용할 때마다 일일이 데이터의 최상위 부터 해당 데이터가 있는 곳 까지 도트체인으로 호출해서 사용하게 되면 코드의 길이가 매우 길어지게 됩니다. 그러므로 상위에 따로 변수 형태로 분리해서 중복되는 코드를 줄입니다.