### PR TITLE
:recycle: [#184][Refactor] : API 반환 값들에 Readonly 적용

### DIFF
--- a/src/Components/Statistics/Player/Player.tsx
+++ b/src/Components/Statistics/Player/Player.tsx
@@ -9,7 +9,9 @@ import PlayerImg from '../../PlayerImg';
 // 후스코어처럼 선수 포메이션 형태 구현하고 거기에 hover하면 각종 정보들 보여주는 식으로?
 const Player = ({ matchInfos }: MatchInfos) => {
   const [myMatchData, ohterMatchData] = [matchInfos[0], matchInfos[1]];
-  const [myPlayerData, ohterPlayerData] = [matchInfos[0].player, matchInfos[1].player];
+
+  // readonly로 설정되어 있으므로 원본을 변경하는 sort를 사용하기 위해 복사해서 사용
+  const [myPlayerData, ohterPlayerData] = [[...matchInfos[0].player], [...matchInfos[1].player]];
   return (
     <PlayerContainerDiv>
       {myMatchData.matchDetail.matchEndType === 2 ? (

--- a/src/Pages/MatchStatistics/MatchStatistics.tsx
+++ b/src/Pages/MatchStatistics/MatchStatistics.tsx
@@ -58,6 +58,8 @@ const MatchStatistics = () => {
 
       setMyMatchInfo(matchDetailResult.matchInfo[indexInfo.mine]);
       setOtherMatchInfo(matchDetailResult.matchInfo[indexInfo.other]);
+      // setMyMatchInfo(JSON.parse(JSON.stringify(matchDetailResult.matchInfo[indexInfo.mine])));
+      // setOtherMatchInfo(JSON.parse(JSON.stringify(matchDetailResult.matchInfo[indexInfo.other])));
     };
     getMatchDetail();
   }, []);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -83,7 +83,7 @@ export type matchInfoType = {
     throughPassSuccess: number; // 스루패스 성공 수
     throughPassTry: number; // 스루패스 시도 수
   };
-  player: {
+  player: readonly {
     // 각 선수들에 대한 정보 (후보선수 포함)
 
     spId: number; // 선수 spid
@@ -115,8 +115,9 @@ export type matchInfoType = {
       tackle: number; // 태클 성공 수
       tackleTry: number; // 태글 시도 수
     };
-  }[]; // 위의 MetaDataSpid는 MetaDataSpid자체를 사용할 때 배열로 선언하면 되지만
-  // 이처럼 matchInfoType안의 특정 값들만 배열로 사용되고 있는 것은 여기서 직접 배열로 선언
+  }[]; // 위의 MetaDataSpid같은 타입들의 경우 , MetaDataSpid자체를 사용할 때 배열로 선언하면 되지만
+  // 이처럼 matchInfoType 안에 있는 일부 값들이 배열로 사용되고 있는 경우, matchInfoType을 사용할때 따로 특정 하위 값들만 배열로 선언할 수 없기에
+  // 여기서 직접 배열로 선언
 
   shoot: {
     // 해당 매치 전체 슛 정보
@@ -138,7 +139,7 @@ export type matchInfoType = {
     shootOutScore: number; // 승부차기 슛 수
     shootPenaltyKick: number; // 패널티킥 슛 수
   };
-  shootDetail: {
+  shootDetail: readonly {
     // 각 슛에 대한 세부 정보(shoot : shootTotal로 찍힌 각 슈팅에 대한 정보)
 
     result: number; // 슛 결과 (1 : ontarget(유효슛) , 2 : offtarget(빗나간 슛) , 3 : goal)
@@ -166,7 +167,7 @@ export interface MatchDetail {
   matchDate: string;
   matchId: string;
   matchType: number;
-  matchInfo: [matchInfoType, matchInfoType]; // 길이가 고정적이므로 튜플 사용
+  matchInfo: readonly [matchInfoType, matchInfoType]; // 길이가 고정적이므로 튜플 사용
 }
 
 // { "tradeDate": "2023-05-31T01:07:25",
@@ -174,6 +175,8 @@ export interface MatchDetail {
 // "spid": 265204024,
 // "grade": 1,
 // "value": 499000000 }
+// TradeLogInfo역시 실제로 객체 배열 형태로 반환되므로 위의 MatchDetail의 하위 타입들처럼 []형태로 사용해도 되는데
+// 우선은 최소 단위로 사용해보고자 객체 형태로 선언하고 사용할때 []를 붙여서 사용
 export interface TradeLogInfo {
   tradeDate: string;
   saleSn: string;


### PR DESCRIPTION
보다 타입의 안전성을 개선하기 위해 , API로 호출한 값들 중 ,MatchDetail타입의 matchInfo값에 들어있는 모든 배열 및 튜플 형태에 대해 Readonly옵션을 추가 합니다