### PR TITLE
🐛 [#188][BUG] : Shoot 컴포넌트 어시스트,득점 좌표 계산 공식 전면 수정

### DIFF
--- a/src/Components/Statistics/Player/Player.tsx
+++ b/src/Components/Statistics/Player/Player.tsx
@@ -12,6 +12,7 @@ const Player = ({ matchInfos }: MatchInfos) => {
 
   // readonly로 설정되어 있으므로 원본을 변경하는 sort를 사용하기 위해 복사해서 사용
   const [myPlayerData, ohterPlayerData] = [[...matchInfos[0].player], [...matchInfos[1].player]];
+
   return (
     <PlayerContainerDiv>
       {myMatchData.matchDetail.matchEndType === 2 ? (

--- a/src/Components/Statistics/Player/WhoScored/WhoScored.styled.ts
+++ b/src/Components/Statistics/Player/WhoScored/WhoScored.styled.ts
@@ -1,0 +1,4 @@
+import styled from 'styled-components';
+
+export const WhoScoredContainerDiv = styled.div``;
+export const tmp = '';

--- a/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
+++ b/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const WhoScored = () => {
+  return <div>sad</div>;
+};
+
+export default WhoScored;

--- a/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
+++ b/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { WhoScoredContainerDiv } from './WhoScored.styled';
 
 const WhoScored = () => {
-  return <div>sad</div>;
+  return <WhoScoredContainerDiv>sad</WhoScoredContainerDiv>;
 };
 
 export default WhoScored;

--- a/src/Components/Statistics/Player/WhoScored/index.ts
+++ b/src/Components/Statistics/Player/WhoScored/index.ts
@@ -1,0 +1,3 @@
+import WhoScored from './WhoScored';
+
+export default WhoScored;

--- a/src/Components/Statistics/Shoot/Shoot.tsx
+++ b/src/Components/Statistics/Shoot/Shoot.tsx
@@ -276,6 +276,8 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
     slidesToScroll: 1,
   };
   console.log(myGoalData);
+  console.log(otherGoalData);
+
   return (
     <ShootContainerDiv>
       {myMatchData.matchDetail.matchEndType === 2 ? (

--- a/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
+++ b/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
@@ -45,21 +45,21 @@ const SoccerGround = ({ goalData }: any) => {
         <polyline points="1100,481.6 1045,481.6 1045,298.4 1100,298.4 1100,591.6 935,591.6 935,188.4 1100,188.4" className="line" />
 
         {/* 축구장 라인 부분부터 좌표가 시작해야 하므로 x와y에 각각 -40을 해줘야 함 */}
-        {goalData.assist && (
+        {/* {goalData.assist && (
           <>
-            <circle cx={goalData.assistX * 1150 - 40} cy={(1 - goalData.assistY) * 780 - 40} r="10" fill="blue" />
+            <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />
             <line
-              x1={goalData.assistX * 1150 - 40}
-              y1={(1 - goalData.assistY) * 780 - 40}
-              x2={goalData.x * 1150 - 40}
-              y2={(1 - goalData.y) * 780 - 40}
+              x1={goalData.assistX * 1070 + 40}
+              y1={goalData.assistY * 700 + 40}
+              x2={goalData.x * 1070 + 40}
+              y2={goalData.y * 700 + 40}
               stroke="black"
               strokeWidth={5}
               markerEnd="url(#arrowhead)"
             />
           </>
         )}
-        <circle cx={goalData.x * 1150 - 40} cy={(1 - goalData.y) * 780 - 40} r="10" fill="red" />
+        <circle cx={goalData.x * 1070 + 40} cy={goalData.y * 700 + 40} r="10" fill="red" /> */}
       </SoccerFieldSvg>
     </div>
   );

--- a/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
+++ b/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
@@ -45,7 +45,7 @@ const SoccerGround = ({ goalData }: any) => {
         <polyline points="1100,481.6 1045,481.6 1045,298.4 1100,298.4 1100,591.6 935,591.6 935,188.4 1100,188.4" className="line" />
 
         {/* 축구장 라인 부분부터 좌표가 시작해야 하므로 x와y에 각각 -40을 해줘야 함 */}
-        {/* {goalData.assist && (
+        {goalData.assist && (
           <>
             <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />
             <line
@@ -59,7 +59,7 @@ const SoccerGround = ({ goalData }: any) => {
             />
           </>
         )}
-        <circle cx={goalData.x * 1070 + 40} cy={goalData.y * 700 + 40} r="10" fill="red" /> */}
+        <circle cx={goalData.x * 1070 + 40} cy={goalData.y * 700 + 40} r="10" fill="red" />
       </SoccerFieldSvg>
     </div>
   );


### PR DESCRIPTION
Shoot 컴포넌트에서 svg로 그려진 축구필드에 득점 및 어시스트 좌표를 보여주는 과정에서 있었던 계산 로직을 전면적으로 수정합니다