### PR TITLE
✨ [#192][Feat] : Shoot 컴포넌트 어시스트 , 골에 사용된 화살표 수정

### DIFF
--- a/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
+++ b/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
@@ -44,7 +44,6 @@ const SoccerGround = ({ goalData }: any) => {
         <polyline points="50,481.6 105,481.6 105,298.4 50,298.4 50,591.6 215,591.6 215,188.4 50,188.4" className="line" />
         <polyline points="1100,481.6 1045,481.6 1045,298.4 1100,298.4 1100,591.6 935,591.6 935,188.4 1100,188.4" className="line" />
 
-        {/* 축구장 라인 부분부터 좌표가 시작해야 하므로 x와y에 각각 -40을 해줘야 함 */}
         {goalData.assist && (
           <>
             <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />

--- a/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
+++ b/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
@@ -44,20 +44,16 @@ const SoccerGround = ({ goalData }: any) => {
         <polyline points="50,481.6 105,481.6 105,298.4 50,298.4 50,591.6 215,591.6 215,188.4 50,188.4" className="line" />
         <polyline points="1100,481.6 1045,481.6 1045,298.4 1100,298.4 1100,591.6 935,591.6 935,188.4 1100,188.4" className="line" />
 
-        {goalData.assist && (
-          <>
-            <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />
-            <line
-              x1={goalData.assistX * 1070 + 40}
-              y1={goalData.assistY * 700 + 40}
-              x2={goalData.x * 1070 + 40}
-              y2={goalData.y * 700 + 40}
-              stroke="black"
-              strokeWidth={5}
-              markerEnd="url(#arrowhead)"
-            />
-          </>
-        )}
+        {goalData.assist && <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />}
+        <line
+          x1={goalData.x * 1070 + 40}
+          y1={goalData.y * 700 + 40}
+          x2={1140 - 40}
+          y2={780 * 0.5}
+          stroke="black"
+          strokeWidth={5}
+          markerEnd="url(#arrowhead)"
+        />
         <circle cx={goalData.x * 1070 + 40} cy={goalData.y * 700 + 40} r="10" fill="red" />
       </SoccerFieldSvg>
     </div>


### PR DESCRIPTION
실제 축구에서 어시스트를 받고 나서 골을 넣은 선수가 드리블을 하면서 많은 거리를 이동 한 뒤에 골을 넣었을 경우 실제 정보와 차이가 발생하게 되므로 어시스트 -> 골로 연결된 화살표를 제거합니다 대신, 골을 넣은 선수의 슈팅 위치에서 골대 방향으로 화살표를 추가합니다