### PR TITLE
:bug: [#194][BUG] : Shoot 컴포넌트 슛 데이터 API 반환 값 오류 에러 수정

### DIFF
--- a/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
+++ b/src/Components/MatchResultsByMatchTypes/MatchResultsByMatchTypes.styled.ts
@@ -32,7 +32,7 @@ export const WinningpercentageDiv = styled.div`
     margin-bottom: 0; // h2기본 margin 제거
   }
   span {
-    color: gray;
+    color: black;
     white-space: nowrap;
   }
   ul {

--- a/src/Components/Statistics/Shoot/Shoot.styled.ts
+++ b/src/Components/Statistics/Shoot/Shoot.styled.ts
@@ -61,7 +61,7 @@ export const AssistAndScoreDiv = styled.div<AssistProps>`
   width: 100%;
   display: flex;
   //justify-content: space-between;
-  justify-content: ${(props) => (props.assist ? 'space-between' : 'center')};
+  justify-content: ${(props) => (props.assist && props.assistSpId !== -1 ? 'space-between' : 'center')};
   align-items: center;
 `;
 

--- a/src/Components/Statistics/Shoot/Shoot.tsx
+++ b/src/Components/Statistics/Shoot/Shoot.tsx
@@ -277,6 +277,7 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
   };
   console.log(myGoalData);
   console.log(otherGoalData);
+  // console.log(myPlayerData);
 
   return (
     <ShootContainerDiv>
@@ -310,8 +311,8 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
                   </Goal>
                 </AssistAndGoalCircleDiv>
                 <SoccerField goalData={myGoalData[myGoalIndex]} />
-                <AssistAndScoreDiv assist={myGoalData[myGoalIndex].assist}>
-                  {myGoalData[myGoalIndex].assist && (
+                <AssistAndScoreDiv assist={myGoalData[myGoalIndex].assist} assistSpId={myGoalData[myGoalIndex].assistSpId}>
+                  {myGoalData[myGoalIndex].assist && myGoalData[myGoalIndex].assistSpId !== -1 && (
                     <BoxDiv>
                       <GoalParagraph>ASSIST</GoalParagraph>
 
@@ -327,7 +328,7 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
                       </PlayerInfoDiv>
                     </BoxDiv>
                   )}
-                  {myGoalData[myGoalIndex].assist && <StyledBiSolidRightArrow />}
+                  {myGoalData[myGoalIndex].assist && myGoalData[myGoalIndex].assistSpId !== -1 && <StyledBiSolidRightArrow />}
 
                   <BoxDiv>
                     <GoalParagraph>GOAL</GoalParagraph>
@@ -390,8 +391,8 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
                   </Goal>
                 </AssistAndGoalCircleDiv>
                 <SoccerField goalData={otherGoalData[otherGoalIndex]} />
-                <AssistAndScoreDiv assist={otherGoalData[otherGoalIndex].assist}>
-                  {otherGoalData[otherGoalIndex].assist && (
+                <AssistAndScoreDiv assist={otherGoalData[otherGoalIndex].assist} assistSpId={otherGoalData[otherGoalIndex].assistSpId}>
+                  {otherGoalData[otherGoalIndex].assist && otherGoalData[otherGoalIndex].assistSpId !== -1 && (
                     <BoxDiv>
                       <GoalParagraph>ASSIST</GoalParagraph>
 
@@ -407,7 +408,7 @@ const Shoot = ({ matchInfos }: MatchInfos) => {
                       </PlayerInfoDiv>
                     </BoxDiv>
                   )}
-                  {otherGoalData[otherGoalIndex].assist && <StyledBiSolidRightArrow />}
+                  {otherGoalData[otherGoalIndex].assist && otherGoalData[otherGoalIndex].assistSpId !== -1 && <StyledBiSolidRightArrow />}
                   <BoxDiv>
                     <GoalParagraph>GOAL</GoalParagraph>
                     <PlayerInfoDiv>

--- a/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
+++ b/src/Components/Statistics/Shoot/SoccerField/SoccerField.tsx
@@ -44,7 +44,9 @@ const SoccerGround = ({ goalData }: any) => {
         <polyline points="50,481.6 105,481.6 105,298.4 50,298.4 50,591.6 215,591.6 215,188.4 50,188.4" className="line" />
         <polyline points="1100,481.6 1045,481.6 1045,298.4 1100,298.4 1100,591.6 935,591.6 935,188.4 1100,188.4" className="line" />
 
-        {goalData.assist && <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />}
+        {goalData.assist && goalData.assistSpId !== -1 && (
+          <circle cx={goalData.assistX * 1070 + 40} cy={goalData.assistY * 700 + 40} r="10" fill="blue" />
+        )}
         <line
           x1={goalData.x * 1070 + 40}
           y1={goalData.y * 700 + 40}

--- a/src/Components/Statistics/Statistics.tsx
+++ b/src/Components/Statistics/Statistics.tsx
@@ -18,7 +18,7 @@ import { MatchStatisticsProps } from '../../types/props';
 import { convertYardtoMeter } from '../../utils/MatchStatistics';
 
 const Statistics = ({ myMatchInfo, otherMatchInfo }: MatchStatisticsProps) => {
-  const [statisticsMode, setStatisticsMode] = useState('pass');
+  const [statisticsMode, setStatisticsMode] = useState('shoot');
 
   // const [myMatch, otherMatch] = [matchDetail.matchInfo[myDataIndex.mine], matchDetail.matchInfo[myDataIndex.other]];
   const [myNickName, otherNickName] = [myMatchInfo.nickname, otherMatchInfo.nickname];

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -72,4 +72,5 @@ export interface NickNameProps {
 
 export interface AssistProps {
   assist: boolean;
+  assistSpId: number;
 }


### PR DESCRIPTION
슛 데이터 관련한 API를 호출하면 해당 골이 어시스트 유무가 있는지를 알려주는 MatchDetail.matchInfo[0].shootDetail[0].assist 값이 true이면 반드시 어시스트를 한 선수의 고유id를 의미하는 MatchDetail.matchInfo[0].shootDetail[0].assistSpId 의 값이 존재해야 합니다. 그렇지만 이 부분이 .assist가 true 임에도 불구하고 -1로 반환되는 오류가 존재합니다. 그러므로 해당 데이터를 조건부 렌더링하는 부분에다가 assistSpId 의 값이 -1이 아닌 경우의 조건을 추가합니다