### PR TITLE
:sparkles: [#198][BUG] : Player 컴포넌트 MVP 선수 svg 표기 오류 수정

### DIFF
--- a/src/Components/Statistics/Player/WhoScored/WhoScored.styled.ts
+++ b/src/Components/Statistics/Player/WhoScored/WhoScored.styled.ts
@@ -27,7 +27,7 @@ export const WhoScoredSvg = styled.svg`
   .player {
     fill: #ffffff;
     font-weight: bolder;
-    font-size: 6px;
+    font-size: 5px;
   }
 
   #hoverDiv {

--- a/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
+++ b/src/Components/Statistics/Player/WhoScored/WhoScored.tsx
@@ -14,7 +14,6 @@ const WhoScored = ({ matchInfos }: MatchInfos) => {
   ];
 
   const bestPlayer = [...myPlayerData, ...ohterPlayerData].sort((a, b) => b.status.spRating - a.status.spRating);
-  console.log(bestPlayer);
 
   const [myStartingPlayerData, otherStartingPlayerData] = [
     myPlayerData.filter((i) => {
@@ -113,7 +112,7 @@ const WhoScored = ({ matchInfos }: MatchInfos) => {
                   height="50"
                   fill="transparent"
                 />
-                {i.spId === bestPlayer[0].spId ? (
+                {i.spId === bestPlayer[0].spId && i.status.spRating === bestPlayer[0].status.spRating ? (
                   <g
                     transform={`translate(${myPositionCord[convertPosition(i.spPosition)].x - 14}, ${
                       myPositionCord[convertPosition(i.spPosition)].y - 17
@@ -171,7 +170,7 @@ const WhoScored = ({ matchInfos }: MatchInfos) => {
                   height="50"
                   fill="transparent"
                 />
-                {i.spId === bestPlayer[0].spId ? (
+                {i.spId === bestPlayer[0].spId && i.status.spRating === bestPlayer[0].status.spRating ? (
                   <g
                     transform={`translate(${otherPositionCord[convertPosition(i.spPosition)].x - 14}, ${
                       otherPositionCord[convertPosition(i.spPosition)].y - 17


### PR DESCRIPTION
Player 컴포넌트에서 평점이 가장 높은 선수를 선수 고유id값인 spid로 구별해서 별 모양의 svg 로 표기 했지만, 상대 팀도 동일선수를 사용할 시, MVP선수가 2명이 발생하는 현상을 수정 합니다