### PR TITLE
:sparkles: [#214][BUG] : 선택한 포지션의 데이터 표본이 없을 때의 에러 해결

### DIFF
--- a/src/Components/NoResultPositionStatistics/NoResultPositionStatistics.styled.ts
+++ b/src/Components/NoResultPositionStatistics/NoResultPositionStatistics.styled.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const NoResultPositionStatisticsContainerDiv = styled.div`
+  box-shadow: 0px 5px 15px rgba(0, 0, 0, 1);
+  border-radius: 40px;
+  min-width: 500px;
+  margin-bottom: 50px;
+`;
+
+export const PositionAndMatchCount = styled.div`
+  display: flex;
+  justify-content: space-around;
+  font-size: 1.1rem;
+  align-items: center;
+`;
+
+export const NoResultMessage = styled.p`
+  font-weight: bolder;
+  color: red;
+`;

--- a/src/Components/NoResultPositionStatistics/NoResultPositionStatistics.tsx
+++ b/src/Components/NoResultPositionStatistics/NoResultPositionStatistics.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NoResultMessage, NoResultPositionStatisticsContainerDiv, PositionAndMatchCount } from './NoResultPositionStatistics.styled';
+import { convertPosition } from '../../utils/MatchStatistics';
+
+const NoResultPositionStatistics = ({ errorPositionId }: any) => {
+  console.log(errorPositionId);
+  return (
+    <NoResultPositionStatisticsContainerDiv>
+      <PositionAndMatchCount>
+        <p>
+          포지션 : <b>{convertPosition(errorPositionId)}</b>
+        </p>
+        <NoResultMessage>해당 포지션에 대한 정보가 존재하지 않습니다</NoResultMessage>
+      </PositionAndMatchCount>
+    </NoResultPositionStatisticsContainerDiv>
+  );
+};
+
+export default NoResultPositionStatistics;

--- a/src/Components/NoResultPositionStatistics/index.ts
+++ b/src/Components/NoResultPositionStatistics/index.ts
@@ -1,0 +1,3 @@
+import NoResultPositionStatistics from './NoResultPositionStatistics';
+
+export default NoResultPositionStatistics;

--- a/src/Pages/PositionGuide/PositionGuide.tsx
+++ b/src/Pages/PositionGuide/PositionGuide.tsx
@@ -11,6 +11,7 @@ import {
 } from './PositionGuide.styled';
 import Footer from '../../Components/Footer';
 import Navbar from '../../Components/Navbar';
+import NoResultPositionStatistics from '../../Components/NoResultPositionStatistics';
 import PlayerNameInput from '../../Components/PlayerNameInput';
 import PositionStatistics from '../../Components/PositionStatistics';
 import SelectPostition from '../../Components/SelectPostition';
@@ -57,6 +58,7 @@ const PositionGuide = () => {
     }
   }, [seasonId, confirmedPlayerNameInput, confirmedPositionId]);
 
+  console.log(rankerInfo);
   return (
     <>
       <Navbar page="PositionGuide" />
@@ -84,6 +86,11 @@ const PositionGuide = () => {
           confirmedPositionId.length !== 0 &&
           rankerInfo.length !== 0 &&
           rankerInfo.map((i, index) => {
+            if (i[0].createDate === 'Could not found and players of rankers') {
+              console.log(i[0].errorPositionId);
+              return <NoResultPositionStatistics errorPositionId={i[0].errorPositionId} key={index} />;
+            }
+
             return <PositionStatistics key={index} rankerInfo={i[0]} confirmedPositionId={i[0].spPosition} />;
           })}
       </PositionGuideContainerDiv>

--- a/src/Services/FifaData.ts
+++ b/src/Services/FifaData.ts
@@ -10,6 +10,7 @@ import {
   NexonUserInfo,
   TradeLogInfo,
 } from '../types/api';
+import { getErrorMessage, getErrorName } from '../utils/getErrorMessage';
 
 export default class FIFAData {
   instance;
@@ -179,14 +180,22 @@ export default class FIFAData {
   };
 
   getTopRankerPlayerInfo = async (matchtype: number, players: any): Promise<any> => {
-    const result = await this.instance.get(`/rankers/status`, {
-      params: {
-        matchtype,
-        players,
-      },
-    });
-    console.log(result);
-
-    return result.data;
+    try {
+      const result = await this.instance.get(`/rankers/status`, {
+        params: {
+          matchtype,
+          players,
+        },
+      });
+      return result.data;
+    } catch (error) {
+      return [
+        {
+          type: 'error',
+          createDate: 'Could not found and players of rankers',
+          errorPositionId: JSON.parse(players)[0].po,
+        },
+      ];
+    }
   };
 }


### PR DESCRIPTION
포지션 추천 페이지에서 포지션을 선택했을 때 , 해당 선수의 선택한 포지션에 대한 랭커들의 데이터 표본이 없을 경우, 피파온라인4 API에서는 404에러를 발생 시킵니다. 그러므로 이에 따른 에러 처리와 UI레벨에서도 다른 컴포넌트를 보여줍니다