### PR TITLE
:sparkles: [#222][Feat] : 로그인 시 기존 계정에서 사용하는 닉네임 변경 기능 추가

### DIFF
--- a/src/Components/AskUseExistNickNameModal/AskUseExistNickNameModal.styled.ts
+++ b/src/Components/AskUseExistNickNameModal/AskUseExistNickNameModal.styled.ts
@@ -1,0 +1,104 @@
+import styled, { keyframes } from 'styled-components';
+
+const modalAnimation = keyframes`
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0;
+  }
+  50% { //살짝 커졌다 작아져야 보다 생동감 있는 애니메이션이 구현된다
+    transform: translate(-50%, -50%) scale(1.2);
+    opacity: 0.5;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+`;
+
+export const ModalDiv = styled.div`
+  background-color: red;
+  position: absolute;
+
+  top: 50%;
+  min-width: 455px;
+  min-height: 380px;
+  left: 50%;
+  border: 2px solid lightgray;
+  border-radius: 15px;
+  background-color: #eee;
+  transform: translate(-50%, -50%) scale(1);
+  animation: ${modalAnimation} 0.2s ease-out;
+`;
+
+export const ModalContentForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 30px;
+  border-radius: 10px;
+`;
+
+export const DiscriptionHeading = styled.h2`
+  font-weight: bold;
+`;
+
+export const FormContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+  height: 60px;
+  width: 100%;
+`;
+
+export const NickNameInputDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const NickNameInput = styled.input`
+  width: 50%;
+  height: 30px;
+  margin-top: 7%;
+  margin-bottom: 5%;
+  border: none;
+  border-radius: 5px;
+  &:focus {
+    outline: 2px solid forestgreen;
+  }
+`;
+
+export const SubmitInput = styled.input`
+  height: 100%;
+  border-radius: 5px;
+  border: none;
+  box-shadow: inset 0 0 0 0.5px #000;
+  width: 35%;
+  cursor: pointer;
+  color: forestgreen;
+  font-weight: bolder;
+  font-size: 1.2rem;
+  margin-left: 15%;
+  &:hover {
+    transform: translateY(-5px);
+  }
+  transition: transform 0.3s ease;
+`;
+
+export const GoBackButton = styled.button`
+  height: 100%;
+  border-radius: 5px;
+  border: none;
+  box-shadow: inset 0 0 0 0.5px black;
+  width: 35%;
+  cursor: pointer;
+  color: black;
+  font-weight: bolder;
+  font-size: 1.2rem;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+  transition: transform 0.3s ease;
+`;

--- a/src/Components/AskUseExistNickNameModal/AskUseExistNickNameModal.tsx
+++ b/src/Components/AskUseExistNickNameModal/AskUseExistNickNameModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ModalDiv } from './AskUseExistNickNameModal.styled';
+import { useLoginAPI } from '../../Context/Firebase/LoginContext';
+import { useModalAPI } from '../../Context/Modal/ModalContext';
+import { useUserObjAPI } from '../../Context/UserObj/UserObjContext';
+import AskNickNameModal from '../AskNickNameModal';
+
+const AskUseExistNickNameModal = () => {
+  const { closeModal } = useModalAPI()!;
+  const { isLoggedIn, setIsLoggedIn } = useLoginAPI()!; // context로 관리하는 로그인이 되어 있는지 알려주는 상태
+  const { isModalOpen, openModal } = useModalAPI()!; // context로 관리하는 현재 모달이 열렸는지 알려주는 상태
+  const { userObj, setUserObj } = useUserObjAPI()!; // context로 관리하는 현재 로그인 중인 유저의 정보
+  const onClick = (value: boolean) => {
+    closeModal(); // 먼저 닫고 새로운 모달을 열어야 함
+    if (!value) {
+      openModal(
+        <ModalDiv>
+          <AskNickNameModal />
+        </ModalDiv>,
+      );
+    }
+  };
+  return (
+    <div>
+      <h1>기존 닉네임 &quot;{userObj?.nickname}&quot; 을 그대로 사용 하시나요?</h1>
+      <button type="button" onClick={() => onClick(true)}>
+        네
+      </button>
+      <button type="button" onClick={() => onClick(false)}>
+        아니오
+      </button>
+    </div>
+  );
+};
+
+export default AskUseExistNickNameModal;

--- a/src/Components/AskUseExistNickNameModal/index.ts
+++ b/src/Components/AskUseExistNickNameModal/index.ts
@@ -1,0 +1,3 @@
+import AskUseExistNickNameModal from './AskUseExistNickNameModal';
+
+export default AskUseExistNickNameModal;

--- a/src/Pages/ChooseModeAndLogin/ChooseModeAndLogin.styled.ts
+++ b/src/Pages/ChooseModeAndLogin/ChooseModeAndLogin.styled.ts
@@ -79,16 +79,18 @@ export const SelectModeHeading = styled.h1`
 // `;
 
 export const ButtonsDiv = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
 `;
 
 export const LogoutButton = styled.button`
   cursor: pointer;
-  width: 300px;
+  max-width: 500px;
+  min-width: 400px;
   height: 250px;
-  margin-left: 100px;
+  margin-left: 200px;
   border-radius: 20px;
   font-size: 2rem;
   border: none;
@@ -119,7 +121,8 @@ export const LogoutButton = styled.button`
 
 export const LoginModeButton = styled.button<IsLoggedIn>`
   cursor: pointer;
-  min-width: 300px;
+  max-width: 500px;
+  min-width: 370px;
   height: 250px;
   font-size: 2rem;
   border: none;


### PR DESCRIPTION
구글 로그인을 진행할 때 기존에는 최초 로그인시 입력한 피파온라인4 계정만 사용 가능했지만, 이제는 로그인을 할 때마다 이전 로그인 기록이 존재한다면 다른 닉네임을 사용할지 모달창을 통해 선택할 수 있도록 합니다. 또한 닉네임 입력창에 공백을 허용하지 않도록 수정 합니다.